### PR TITLE
Mapping cache

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdk 21
         targetSdk 32
-        versionCode 1
-        versionName "1.2.1"
+        versionCode 2
+        versionName "1.3.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/xyz/rodit/xposed/mappings/LoadScheme.java
+++ b/app/src/main/java/xyz/rodit/xposed/mappings/LoadScheme.java
@@ -1,7 +1,5 @@
 package xyz.rodit.xposed.mappings;
 
-import java.io.File;
-
 public enum LoadScheme {
     // Attempt to load latest mappings immediately on package load (very unsafe, no context available yet)
     CACHED_IMMEDIATE,

--- a/app/src/main/java/xyz/rodit/xposed/mappings/LoadScheme.java
+++ b/app/src/main/java/xyz/rodit/xposed/mappings/LoadScheme.java
@@ -1,0 +1,12 @@
+package xyz.rodit.xposed.mappings;
+
+import java.io.File;
+
+public enum LoadScheme {
+    // Attempt to load latest mappings immediately on package load (very unsafe, no context available yet)
+    CACHED_IMMEDIATE,
+    // Attempt to load cached mappings as soon as context is acquired (by hooking user provided context class) and acquiring correct build number
+    CACHED_ON_CONTEXT,
+    // Load mappings when configuration service is bound
+    SERVICE
+}

--- a/app/src/main/java/xyz/rodit/xposed/mappings/MappingsManager.java
+++ b/app/src/main/java/xyz/rodit/xposed/mappings/MappingsManager.java
@@ -1,0 +1,67 @@
+package xyz.rodit.xposed.mappings;
+
+import android.content.Context;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import de.robv.android.xposed.XposedBridge;
+import xyz.rodit.xposed.utils.StreamUtils;
+
+public class MappingsManager {
+
+    private final File dir;
+
+    public MappingsManager(Context context) {
+        this(new File(context.getFilesDir(), "mappings"));
+    }
+
+    public MappingsManager(File dir) {
+        this.dir = dir;
+
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+    }
+
+    public List<Integer> getAvailable() {
+        List<Integer> available = new ArrayList<>();
+        File[] files = dir.listFiles(f -> f.getName().endsWith(".json"));
+        if (files != null) {
+            for (File file : files) {
+                try {
+                    available.add(Integer.valueOf(file.getName().split("\\.")[0]));
+                } catch (NumberFormatException e) {
+                    // ignored
+                }
+            }
+        }
+
+        Collections.sort(available);
+        return available;
+    }
+
+    public File getMappingsFile(int versionCode) {
+        return new File(dir, versionCode + ".json");
+    }
+
+    public String get(int versionCode) {
+        try {
+            return StreamUtils.readFile(getMappingsFile(versionCode));
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    public void put(int versionCode, String content) {
+        try {
+            StreamUtils.writeFile(getMappingsFile(versionCode), content);
+        } catch (IOException e) {
+            XposedBridge.log("Error putting mappings in cache.");
+            e.printStackTrace();
+        }
+    }
+}

--- a/app/src/main/java/xyz/rodit/xposed/utils/StreamUtils.java
+++ b/app/src/main/java/xyz/rodit/xposed/utils/StreamUtils.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.util.Scanner;
 
 public class StreamUtils {
@@ -27,6 +28,12 @@ public class StreamUtils {
     public static String readFile(File file) throws IOException {
         try (Scanner scanner = new Scanner(file)) {
             return scanner.useDelimiter("\\A").next();
+        }
+    }
+
+    public static void writeFile(File file, String contents) throws IOException {
+        try (PrintWriter writer = new PrintWriter(file)) {
+            writer.write(contents);
         }
     }
 


### PR DESCRIPTION
Implements mapping cache and mapping load schemes (mappings can be loaded as soon as context is hooked or unsafely before, as well as when service provides mappings).